### PR TITLE
improve react template quality and fix renovate ogma sync

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,24 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>Linkurious/renovate-config"
+  ],
+  "regexManagers": [
+    {
+      "description": "Keep @linkurious/ogma version in template package.json URLs in sync with the root package",
+      "fileMatch": ["^templates/[^/]+/package\\.json$"],
+      "matchStrings": [
+        "get\\.linkurio\\.us/api/get/npm/ogma/(?<currentValue>[^/]+)/\\?secret=YOUR_API_KEY"
+      ],
+      "depNameTemplate": "@linkurious/ogma",
+      "datasourceTemplate": "npm",
+      "registryUrlTemplate": "https://nexus3.linkurious.net/repository/npm/"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Group root and template @linkurious/ogma bumps into one PR",
+      "matchDepNames": ["@linkurious/ogma"],
+      "groupName": "@linkurious/ogma"
+    }
   ]
 }

--- a/templates/react/_gitignore
+++ b/templates/react/_gitignore
@@ -1,2 +1,6 @@
 node_modules
 dist
+*.local
+.env
+.env.local
+.DS_Store

--- a/templates/react/package.json
+++ b/templates/react/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@linkurious/ogma": "6.0.2",
+    "@linkurious/ogma": "https://get.linkurio.us/api/get/npm/ogma/6.0.2/?secret=YOUR_API_KEY",
     "@linkurious/ogma-react": "latest",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/templates/react/package.json
+++ b/templates/react/package.json
@@ -8,8 +8,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@linkurious/ogma": "https://get.linkurio.us/api/get/npm/ogma/6.0.2/?secret=YOUR_API_KEY",
-    "@linkurious/ogma-react": "5.1.15",
+    "@linkurious/ogma": "6.0.2",
+    "@linkurious/ogma-react": "latest",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/templates/react/src/App.tsx
+++ b/templates/react/src/App.tsx
@@ -1,5 +1,6 @@
-import type { RawGraph } from '@linkurious/ogma';
-import { Ogma, NodeStyle, EdgeStyle } from '@linkurious/ogma-react';
+import { useState } from 'react';
+import { Node as OgmaNode, type RawGraph } from '@linkurious/ogma';
+import { Ogma, NodeStyle, EdgeStyle, useEvent } from '@linkurious/ogma-react';
 
 const graph: RawGraph = {
   nodes: [
@@ -14,13 +15,31 @@ const graph: RawGraph = {
 };
 
 export default function App() {
+  const [selected, setSelected] = useState<OgmaNode | null>(null);
+
+  const onClick = useEvent('click', ({ target }) => {
+    setSelected(target && target.isNode ? target : null);
+  });
+
   return (
-    <Ogma
-      graph={graph}
-      onReady={(ogma) => ogma.layouts.force({ locate: true })}
-    >
-      <NodeStyle attributes={{ color: '#61dafb', radius: 12 }} />
-      <EdgeStyle attributes={{ color: '#555' }} />
-    </Ogma>
+    <>
+      <Ogma
+        graph={graph}
+        onReady={(ogma) => ogma.layouts.force({ locate: true })}
+        onClick={onClick}
+      >
+        <NodeStyle attributes={{ color: '#61dafb', radius: 12 }} />
+        <EdgeStyle attributes={{ color: '#555' }} />
+      </Ogma>
+      {selected && (
+        <div style={{
+          position: 'fixed', bottom: 16, left: 16,
+          background: '#fff', padding: '8px 12px', borderRadius: 6,
+          boxShadow: '0 2px 8px rgba(0,0,0,0.15)', fontFamily: 'sans-serif',
+        }}>
+          Selected: <strong>{String(selected.getAttribute('text') ?? selected.getId())}</strong>
+        </div>
+      )}
+    </>
   );
 }

--- a/templates/react/tsconfig.json
+++ b/templates/react/tsconfig.json
@@ -3,11 +3,12 @@
     "strict": true,
     "target": "ESNext",
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "jsx": "react-jsx",
     "types": ["vite/client"],
+    "lib": ["ESNext", "DOM"],
     "noEmit": true,
     "isolatedModules": true,
     "skipLibCheck": true


### PR DESCRIPTION
## Changes

### React template improvements
- **`@linkurious/ogma-react`**: unpin from `5.1.15` → `latest` (consistent with how `ogma-vue` is declared in the vue template)
- **`tsconfig.json`**: fix `moduleResolution` from `node` → `bundler` (correct for Vite + TS 5+); add `lib: [ESNext, DOM]` for explicit DOM types
- **`App.tsx`**: enrich example with `useState` + `EventListener` to demonstrate the core ogma-react pattern of bridging React state and Ogma events
- **`_gitignore`**: add `.env`, `.env.local`, `*.local`, `.DS_Store` (matches what `create-vite` generates)

### Renovate fix for `@linkurious/ogma` bump PRs (fixes #163)
- Add a `regexManager` to `.github/renovate.json` so Renovate also bumps the ogma version embedded in template `package.json` URLs when it updates the root package
- Group root + template ogma changes into a single PR via `packageRules`

**Root cause of #163:** Renovate's lockfile-only PR bumped the installed ogma to 6.0.3, but the template URLs still had 6.0.2 hardcoded. The test asserts `ogmaDep === ogmaUrl(installedVersion, key)` → version mismatch → CI fails. With the regexManager, future ogma bump PRs will update both together.