### PR TITLE
feat: optional .npmrc registry auth in create-ogma

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,17 @@ async function main(): Promise<void> {
     useNpmrc = result
   }
 
+  // Email is only needed to derive OGMA_DOWNLOAD_KEY when using .npmrc
+  let email = ''
+  if (useNpmrc) {
+    const result = await p.text({
+      message: `Email ${pc.dim('(your get.linkurio.us login email)')}:`,
+      validate: (v) => (v?.trim() ? undefined : 'Email cannot be empty'),
+    })
+    if (p.isCancel(result)) { p.cancel('Cancelled.'); process.exit(1) }
+    email = result as string
+  }
+
   // Ogma AI coding skill (default yes; overridable with --skill / --no-skill)
   let installSkill: boolean
   if (typeof argv.skill === 'boolean') {
@@ -122,7 +133,7 @@ async function main(): Promise<void> {
     `  ${pc.cyan(`cd ${projectName}`)}\n` +
     (useNpmrc
       ? `  ${pc.dim('# set this in your shell, CI secret store, or .env (do not commit the value)')}\n` +
-        `  ${pc.cyan(`export OGMA_DOWNLOAD_KEY=${deriveDownloadKey(apiKey)}`)}\n`
+        `  ${pc.cyan(`export OGMA_DOWNLOAD_KEY=${deriveDownloadKey(email, apiKey)}`)}\n`
       : '') +
     `  ${pc.cyan('npm install')}\n` +
     `  ${pc.cyan('npm run dev')}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,13 +4,13 @@ import path from 'node:path'
 import mri from 'mri'
 import * as p from '@clack/prompts'
 import pc from 'picocolors'
-import { scaffold, TEMPLATES, type Template } from './scaffold.js'
+import { scaffold, TEMPLATES, type Template, deriveDownloadKey } from './scaffold.js'
 import { downloadOgmaSkill } from './skill.js'
 
-const argv = mri<{ template?: string; t?: string; skill?: boolean }>(process.argv.slice(2), {
+const argv = mri<{ template?: string; t?: string; skill?: boolean; npmrc?: boolean }>(process.argv.slice(2), {
   alias: { t: 'template' },
   string: ['template'],
-  boolean: ['skill'],
+  boolean: ['skill', 'npmrc'],
 })
 
 async function main(): Promise<void> {
@@ -57,6 +57,19 @@ async function main(): Promise<void> {
   if (p.isCancel(apiKeyResult)) { p.cancel('Cancelled.'); process.exit(1) }
   const apiKey = apiKeyResult as string
 
+  // Optional: .npmrc registry auth (default no — most projects are private repos)
+  let useNpmrc: boolean
+  if (typeof argv.npmrc === 'boolean') {
+    useNpmrc = argv.npmrc
+  } else {
+    const result = await p.confirm({
+      message: `Generate ${pc.cyan('.npmrc')} for registry auth? ${pc.dim('(keeps secret out of package.json — useful for CI/shared repos)')}`,
+      initialValue: false,
+    })
+    if (p.isCancel(result)) { p.cancel('Cancelled.'); process.exit(1) }
+    useNpmrc = result
+  }
+
   // Ogma AI coding skill (default yes; overridable with --skill / --no-skill)
   let installSkill: boolean
   if (typeof argv.skill === 'boolean') {
@@ -82,7 +95,7 @@ async function main(): Promise<void> {
     fs.rmSync(targetDir, { recursive: true })
   }
 
-  const { ogmaVersion } = await scaffold({ template, projectName, apiKey, targetDir })
+  const { ogmaVersion } = await scaffold({ template, projectName, apiKey, targetDir, useNpmrc })
 
   let skillInstalled = false
   if (installSkill) {
@@ -107,6 +120,10 @@ async function main(): Promise<void> {
     (skillInstalled ? `\n${pc.dim('  Ogma AI skill ready in agents/skills/ogma-skill')}` : '') +
     `\n\n` +
     `  ${pc.cyan(`cd ${projectName}`)}\n` +
+    (useNpmrc
+      ? `  ${pc.dim('# set this in your shell, CI secret store, or .env (do not commit the value)')}\n` +
+        `  ${pc.cyan(`export OGMA_DOWNLOAD_KEY=${deriveDownloadKey(apiKey)}`)}\n`
+      : '') +
     `  ${pc.cyan('npm install')}\n` +
     `  ${pc.cyan('npm run dev')}`,
   )

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -28,10 +28,10 @@ export const ogmaUrl = (version: string, apiKey: string): string =>
 
 /**
  * Derive the OGMA_DOWNLOAD_KEY value expected by the private npm registry.
- * The registry uses HTTP Basic Auth: base64("any:<secret>").
+ * The registry uses HTTP Basic Auth: base64("<email>:<secret>").
  */
-export const deriveDownloadKey = (apiKey: string): string =>
-  Buffer.from(`any:${apiKey}`).toString("base64");
+export const deriveDownloadKey = (email: string, apiKey: string): string =>
+  Buffer.from(`${email}:${apiKey}`).toString("base64");
 
 /**
  * Extract the Ogma version pinned in a template's `package.json` content.

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -20,8 +20,18 @@ const PLACEHOLDER_RE = /"@linkurious\/ogma":\s*"[^"]*YOUR_API_KEY[^"]*"/;
 const OGMA_VERSION_RE = /npm\/ogma\/([^/]+)\//;
 const DEFAULT_OGMA_VERSION = "5.3.8";
 
+export const OGMA_REGISTRY =
+  "https://public-pull.nexus3.linkurious.net/repository/npm-public";
+
 export const ogmaUrl = (version: string, apiKey: string): string =>
   `https://get.linkurio.us/api/get/npm/ogma/${version}/?secret=${apiKey}`;
+
+/**
+ * Derive the OGMA_DOWNLOAD_KEY value expected by the private npm registry.
+ * The registry uses HTTP Basic Auth: base64("any:<secret>").
+ */
+export const deriveDownloadKey = (apiKey: string): string =>
+  Buffer.from(`any:${apiKey}`).toString("base64");
 
 /**
  * Extract the Ogma version pinned in a template's `package.json` content.
@@ -39,6 +49,9 @@ interface ScaffoldOptions {
   projectName: string;
   apiKey: string;
   targetDir: string;
+  /** When true, write an .npmrc pointing @linkurious at the private registry
+   *  and use a plain semver dep instead of embedding the secret in the URL. */
+  useNpmrc?: boolean;
 }
 
 export async function scaffold({
@@ -46,6 +59,7 @@ export async function scaffold({
   projectName,
   apiKey,
   targetDir,
+  useNpmrc = false,
 }: ScaffoldOptions): Promise<{ ogmaVersion: string }> {
   // Templates live in templates/ at the package root (one level up from src/)
   const templateDir = path.join(__dirname, "..", "templates", template);
@@ -69,16 +83,34 @@ export async function scaffold({
     fs.renameSync(gitignoreSrc, path.join(targetDir, ".gitignore"));
   }
 
-  // Patch package.json: set name and inject real Ogma URL
+  // Patch package.json: set name and inject Ogma dependency
   const pkgPath = path.join(targetDir, "package.json");
   let pkgContent = fs.readFileSync(pkgPath, "utf-8");
 
   const ogmaVersion = resolveOgmaVersion(pkgContent);
 
-  pkgContent = pkgContent.replace(
-    PLACEHOLDER_RE,
-    `"@linkurious/ogma": "${ogmaUrl(ogmaVersion, apiKey)}"`,
-  );
+  if (useNpmrc) {
+    // Use a plain semver dep — auth is handled by .npmrc
+    pkgContent = pkgContent.replace(
+      PLACEHOLDER_RE,
+      `"@linkurious/ogma": "${ogmaVersion}"`,
+    );
+
+    // Write .npmrc with ${OGMA_DOWNLOAD_KEY} placeholder (safe to commit)
+    const registryHost = new URL(OGMA_REGISTRY).host;
+    const registryPath = new URL(OGMA_REGISTRY).pathname;
+    fs.writeFileSync(
+      path.join(targetDir, ".npmrc"),
+      `@linkurious:registry=${OGMA_REGISTRY}\n` +
+        `//${registryHost}${registryPath}/:_auth=\${OGMA_DOWNLOAD_KEY}\n`,
+    );
+  } else {
+    // Default: embed the secret directly in the install URL
+    pkgContent = pkgContent.replace(
+      PLACEHOLDER_RE,
+      `"@linkurious/ogma": "${ogmaUrl(ogmaVersion, apiKey)}"`,
+    );
+  }
 
   const pkg = JSON.parse(pkgContent) as Record<string, unknown>;
   pkg.name = projectName;

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -97,11 +97,13 @@ export async function scaffold({
     );
 
     // Write .npmrc with ${OGMA_DOWNLOAD_KEY} placeholder (safe to commit)
-    const registryHost = new URL(OGMA_REGISTRY).host;
-    const registryPath = new URL(OGMA_REGISTRY).pathname;
+    const registryUrl = OGMA_REGISTRY.endsWith("/") ? OGMA_REGISTRY : `${OGMA_REGISTRY}/`;
+    const registry = new URL(registryUrl);
+    const registryHost = registry.host;
+    const registryPath = registry.pathname.replace(/\/$/, "");
     fs.writeFileSync(
       path.join(targetDir, ".npmrc"),
-      `@linkurious:registry=${OGMA_REGISTRY}\n` +
+      `@linkurious:registry=${registryUrl}\n` +
         `//${registryHost}${registryPath}/:_auth=\${OGMA_DOWNLOAD_KEY}\n`,
     );
   } else {


### PR DESCRIPTION
## What

Adds an opt-in prompt after the API key step (default: **No**, so existing behaviour is completely unchanged):

```
◆  Generate .npmrc for registry auth? (keeps secret out of package.json — useful for CI/shared repos)
●  No / Yes
```

## When the user answers Yes

- `package.json` gets a plain semver dep (`"@linkurious/ogma": "6.0.3"`) instead of the full `?secret=` URL
- `.npmrc` is written pointing `@linkurious` at the private Nexus registry with a `${OGMA_DOWNLOAD_KEY}` placeholder (safe to commit)
- The outro shows the exact `export OGMA_DOWNLOAD_KEY=...` command the user needs to run before `npm install`

## When the user answers No (or just hits Enter)

Zero change — the secret is still injected into the install URL as before.

## CLI flag

For non-interactive / scripted use: `--npmrc` / `--no-npmrc`.

## Why optional and default No

Most Ogma projects live in private repos where a secret in `package.json` is not a concern. The `.npmrc` approach is strictly for users who care about CI pipelines and not committing secrets — they'll know to say Yes. Everyone else gets the same simple experience as today.

Related docs: Linkurious/ogma#4645